### PR TITLE
[WIP] support getitem for Metrics

### DIFF
--- a/pb_bss/evaluation/wrapper.py
+++ b/pb_bss/evaluation/wrapper.py
@@ -281,12 +281,13 @@ class OutputMetrics:
             ... )
 
             # Obtain all metrics (recommended)
-            >>> pprint(metrics.as_dict())
-            {'pesq': array([4.53456783, 4.5135417 ]),
-             'stoi': array([-0.60853803, -0.62144604]),
-             'mir_eval_sdr': array([ 27.57700377, 259.71394019]),
-             'mir_eval_sir': array([ 27.57700377, 230.59979431]),
-             'mir_eval_sar': array([210.12091991, 230.58553316]),
+            >>> with np.printoptions(precision=4):
+            ...     pprint(metrics.as_dict())
+            {'pesq': array([4.5346, 4.5135]),
+             'stoi': array([-0.6085, -0.6214]),
+             'mir_eval_sdr': array([ 27.577 , 259.7139]),
+             'mir_eval_sir': array([ 27.577 , 230.5998]),
+             'mir_eval_sar': array([210.1209, 230.5855]),
              'mir_eval_selection': array([1, 0])}
 
             # Obtain particular metric (e.g. pesq)

--- a/tests/test_evaluation/test_wrapper_values.py
+++ b/tests/test_evaluation/test_wrapper_values.py
@@ -55,27 +55,27 @@ def test_input_metrics():
     assert metrics.channels == 3
 
     for k, v in metrics.as_dict().items():
-        if k == 'invasive_sxr_sdr':
+        if k == 'invasive_sdr':
             np.testing.assert_allclose(
                 v, [[ 4.634096,  1.821645,  5.012743],
                     [-4.634303, -1.821825, -5.013139]], rtol=1e-6)
-        elif k == 'invasive_sxr_sir':
+        elif k == 'invasive_sir':
             np.testing.assert_allclose(
                 v, [[ 4.63425 ,  1.821754,  5.013044],
                     [-4.63425 , -1.821754, -5.013044]], rtol=1e-6)
-        elif k == 'invasive_sxr_snr':
+        elif k == 'invasive_snr':
             np.testing.assert_allclose(
                 v, [[49.137625, 47.859369, 46.598417],
                     [44.503376, 46.037615, 41.585373]])
-        elif k == 'mir_eval_sxr_sdr':
+        elif k == 'mir_eval_sdr':
             np.testing.assert_allclose(
                 v, [[16.286314, 15.048399, 17.420134],
                     [14.386505, 14.606471, 12.842921]])
-        elif k == 'mir_eval_sxr_sir':
+        elif k == 'mir_eval_sir':
             np.testing.assert_allclose(
                 v, [[18.172265, 17.323722, 18.868235],
                     [15.523357, 16.609909, 13.310729]])
-        elif k == 'mir_eval_sxr_sar':
+        elif k == 'mir_eval_sar':
             np.testing.assert_allclose(
                 v, [[20.883413, 19.02361 , 22.949934],
                     [20.883413, 19.02361 , 22.949934]])

--- a/tests/test_evaluation/test_wrapper_values.py
+++ b/tests/test_evaluation/test_wrapper_values.py
@@ -123,23 +123,23 @@ def test_output_metrics():
     assert metrics.K_source == 2
 
     for k, v in metrics.as_dict().items():
-        if k == 'invasive_sxr_sdr':
+        if k == 'invasive_sdr':
             np.testing.assert_allclose(v, [49.137625, 44.503376])
-        elif k == 'invasive_sxr_sir':
+        elif k == 'invasive_sir':
             np.testing.assert_allclose(v, np.inf)
-        elif k == 'invasive_sxr_snr':
+        elif k == 'invasive_snr':
             np.testing.assert_allclose(v, [49.137625, 44.503376])
-        elif k == 'mir_eval_sxr_sdr':
+        elif k == 'mir_eval_sdr':
             np.testing.assert_allclose(v, [17.071665, 24.711722])
-        elif k == 'mir_eval_sxr_sir':
+        elif k == 'mir_eval_sir':
             np.testing.assert_allclose(v, [29.423133, 37.060289])
-        elif k == 'mir_eval_sxr_sar':
+        elif k == 'mir_eval_sar':
             np.testing.assert_allclose(v, [17.336992, 24.973125])
         elif k == 'pesq':
             np.testing.assert_allclose(v, [4.37408 , 4.405752])
         elif k == 'stoi':
             np.testing.assert_allclose(v, [0.968833, 0.976151], rtol=1e-6)
-        elif k == 'mir_eval_sxr_selection':
+        elif k == 'mir_eval_selection':
             assert all(v == [0, 1])
         else:
             raise KeyError(k, v)


### PR DESCRIPTION
In #21 @mpariente requested easier access to get a subset of the metrics.

This PR is inspired by the proposal in #21.
Now it is possible to use
`{m: output_metrics[m] for m in metric_names}`
to get a subset of the metrics, without calculating the other metrics.

We still recommend using `output_metrics.as_dict()` to calculate all metrics and save them.

Furthermore, I removed redundant `sxr`'s in the keys of the dictionary (e.g. `mir_eval_sxr_sdr` -> `mir_eval_sdr`)

When these changes are ok, I will also change `InputMetrics`.