### PR TITLE
Switch to alternative pesq implementation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         # Metric dependencies
         'mir_eval',
         'pystoi',
-        'pesq'
+        'pesq @ git+https://github.com/samedii/python-pesq'
     ],
 
     extras_require={


### PR DESCRIPTION
It's a fork of the original pesq repo that does proper error handling (rather than simply exiting with `exit(1);` from C code).

cc FYI @mpariente